### PR TITLE
Stop using the removed magic __stack global getter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -22,7 +21,7 @@ module.exports = process.env.NO_ASSERT
 function assert(expr) {
   if (expr) return;
 
-  var stack = __stack;
+  var stack = callsite();
   var call = stack[1];
   var file = call.getFileName();
   var lineno = call.getLineNumber();


### PR DESCRIPTION
This was broken by https://github.com/visionmedia/callsite/commit/4882cd047cbc234df1d07cfe26f618ecb1a45e5e
