### PR TITLE
Adding support for coffee-script

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,9 +74,12 @@ function readCoffeeLine(file, lineno) {
   var coffee = require('coffee-script');
   var raw = fs.readFileSync(file, 'utf8');
   var noBom = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
-  var src = coffee.compile(noBom, {
-    filename: file,
-    literate: coffee.helpers.isLiterate(file)
-  });
+  var options = { filename: file };
+
+  if (coffee.helpers.isLiterate) {
+    options.literate = coffee.helpers.isLiterate(file);
+  }
+
+  var src = coffee.compile(noBom, options);
   return src.split('\n')[lineno-1];
 }


### PR DESCRIPTION
This could possibly be done without re-compiling the file now that coffee-script patches the prepareStackTrace function, but I didn't find a way of extracting that information from the CallSite objects.

**Assumption:** If a coffee file is being executed, the coffee-script module is available.
