### PR TITLE
Add CommonJS/Node assert methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 
-test:
-	@echo "populate me"
+test: node_modules
+	@./node_modules/.bin/mocha \
+		--reporter spec \
+		--bail
+
+node_modules:
+	@npm install
 
 .PHONY: test

--- a/index.js
+++ b/index.js
@@ -1,38 +1,175 @@
+
 /**
  * Module dependencies.
  */
 
-var AssertionError = require('assert').AssertionError
+var assert = require('assert')
+  , AssertionError = assert.AssertionError
   , callsite = require('callsite')
   , fs = require('fs')
+  , equals = require('equals')
 
-/**
- * Expose `assert`.
- */
-
-module.exports = process.env.NO_ASSERT
-  ? function(){}
-  : assert;
+if (process.env.NO_ASSERT) {
+  var noop = function(){};
+  exports = module.exports = noop;
+  Object.keys(assert).forEach(function (key) {
+    exports[key] = noop;
+  });
+  return;
+}
 
 /**
  * Assert the given `expr`.
+ *
+ * @param {Mixed} expr
+ * @api public
  */
 
-function assert(expr) {
+exports = module.exports = function assert(expr) {
   if (expr) return;
+  throw error();
+};
 
+/**
+ * Assert alias.
+ */
+
+exports.ok = exports;
+
+/**
+ * Assert that `actual == expected`.
+ *
+ * @param {Mixed} actual
+ * @param {Mixed} expected
+ * @api public
+ */
+
+exports.equal = function (actual, expected) {
+  if (actual == expected) return;
+  throw error('==');
+};
+
+/**
+ * Assert that `actual != expected`.
+ *
+ * @param {Mixed} actual
+ * @param {Mixed} expected
+ * @api public
+ */
+
+exports.notEqual = function (actual, expected) {
+  if (actual != expected) return;
+  throw error('!=');
+};
+
+/**
+ * Assert that `actual` is deep-equal to `expected`.
+ *
+ * @param {Mixed} actual
+ * @param {Mixed} expected
+ * @api public
+ */
+
+exports.deepEqual = function (actual, expected) {
+  if (equals(actual, expected)) return;
+  throw error('deep equal');
+};
+
+/**
+ * Assert that `actual` is not deep-equal to `expected`.
+ *
+ * @param {Mixed} actual
+ * @param {Mixed} expected
+ * @api public
+ */
+
+exports.notDeepEqual = function (actual, expected) {
+  if (!equals(actual, expected)) return;
+  throw error('not deep equal');
+};
+
+/**
+ * Assert that `actual === expected`.
+ *
+ * @param {Mixed} actual
+ * @param {Mixed} expected
+ * @api public
+ */
+
+exports.strictEqual = function (actual, expected) {
+  if (actual === expected) return;
+  throw error('===');
+};
+
+/**
+ * Assert that `actual !== expected`.
+ *
+ * @param {Mixed} actual
+ * @param {Mixed} expected
+ * @api public
+ */
+
+exports.notStrictEqual = function (actual, expected) {
+  if (actual !== expected) return;
+  throw error('!==');
+};
+
+/**
+ * Assert that `err == null`.
+ *
+ * @param {Error} err
+ * @api public
+ */
+
+exports.ifError = function (err) {
+  if (err) throw error();
+};
+
+/**
+ * Assert that `fn` throws `expected`.
+ *
+ * @param {Function} fn
+ * @param {Error} [expected]
+ * @api public
+ */
+
+exports.throws = function (fn, expected) {
+  assert.throws(fn, expected);
+};
+
+/**
+ * Assert that `fn` does not throw `expected`.
+ *
+ * @param {Function} fn
+ * @param {Error} [expected]
+ * @api public
+ */
+
+exports.doesNotThrow = function (fn, expected) {
+  assert.doesNotThrow(fn, expected);
+};
+
+/**
+ * Create an `AssertionError` from the call stack.
+ *
+ * @param {String} [operator]
+ * @return {AssertionError}
+ * @api private
+ */
+
+function error(operator) {
   var stack = callsite();
-  var call = stack[1];
+  var call = stack[2];
   var file = call.getFileName();
-  var lineno = call.getLineNumber();
+  var lineno = call.getLineNumber() - 1;
+  var col = call.getColumnNumber() - 1;
   var src = fs.readFileSync(file, 'utf8');
-  var line = src.split('\n')[lineno-1];
-  var src = line.match(/assert\((.*)\)/)[1];
-
-  var err = new AssertionError({
-    message: src,
-    stackStartFunction: stack[0].fun
+  var line = src.split('\n')[lineno].slice(col).trim();
+  var m = line.match(/\((.*)\)/);
+  var msg = m && m[1].trim();
+  if (msg && operator) msg = msg.replace(/\s*,\s*/, ' ' + operator + ' ');
+  return new AssertionError({
+    message: msg || 'assertion failed',
+    stackStartFunction: stack[1].fun
   });
-
-  throw err;
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,35 @@
 {
-    "name": "better-assert"
-  , "version": "1.0.0"
-  , "description": "Better assertions for node, reporting the expr, filename, lineno etc"
-  , "keywords": ["assert", "stack", "trace", "debug"]
-  , "author": "TJ Holowaychuk <tj@vision-media.ca>"
-  , "dependencies": { "callsite": "1.0.0" }
-  , "main": "index"
-  , "engines": { "node": "*" }
+  "name": "better-assert",
+  "version": "1.0.0",
+  "description": "Better assertions for node, reporting the expr, filename, lineno etc",
+  "keywords": [
+    "assert",
+    "stack",
+    "trace",
+    "debug"
+  ],
+  "author": "TJ Holowaychuk <tj@vision-media.ca>",
+  "dependencies": {
+    "callsite": "1.0.0",
+    "equals": "~0.3.2"
+  },
+  "main": "index",
+  "engines": {
+    "node": "*"
+  },
+  "devDependencies": {
+    "mocha": "~1.16.2"
+  },
+  "scripts": {
+    "test": "make test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:visionmedia/better-assert.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/visionmedia/better-assert/issues"
+  },
+  "homepage": "https://github.com/visionmedia/better-assert"
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,181 @@
+
+var assert = require('./');
+
+describe('better-assert', function () {
+  it('should pass', function () {
+    assert(true == true);
+  });
+
+  it('should fail', function () {
+    var err = false;
+    try {
+      assert(false == true);
+    } catch (e) {
+      err = e;
+    }
+    if (!err) throw new Error('didn\'t throw');
+    assert.equal('false == true', err.message);
+  });
+
+  describe('.ok', function () {
+    it('should be an alias of assert', function () {
+      assert.strictEqual(assert, assert.ok);
+    });
+  });
+
+  describe('.equal', function () {
+    it('should pass', function () {
+      assert.equal(1, 1);
+    });
+
+    it('should fail', function () {
+      var err = false;
+      try {
+        assert.equal(1, false);
+      } catch (e) {
+        err = e;
+      }
+      if (!err) throw new Error('didn\'t throw');
+      assert.equal('1 == false', err.message);
+    });
+  });
+
+  describe('.notEqual', function () {
+    it('should pass', function () {
+      assert.notEqual(1, 2);
+    });
+
+    it('should fail', function () {
+      var err = false;
+      try {
+        assert.notEqual(1, 1);
+      } catch (e) {
+        err = e;
+      }
+      if (!err) throw new Error('didn\'t throw');
+      assert.equal('1 != 1', err.message);
+    });
+  });
+
+  describe('.strictEqual', function () {
+    it('should pass', function () {
+      assert.strictEqual(1, 1);
+    });
+
+    it('should fail', function () {
+      var err = false;
+      try {
+        assert.strictEqual(1, '1');
+      } catch (e) {
+        err = e;
+      }
+      if (!err) throw new Error('didn\'t throw');
+      assert.equal('1 === \'1\'', err.message);
+    });
+  });
+
+  describe('.notStrictEqual', function () {
+    it('should pass', function () {
+      assert.notStrictEqual(1, '1');
+    });
+
+    it('should fail', function () {
+      var err = false;
+      try {
+        assert.notStrictEqual(1, 1);
+      } catch (e) {
+        err = e;
+      }
+      if (!err) throw new Error('didn\'t throw');
+      assert.equal('1 !== 1', err.message);
+    });
+  });
+
+  describe('.deepEqual', function () {
+    it('should pass', function () {
+      assert.deepEqual({ foo: 'bar' }, { foo: 'bar' });
+    });
+
+    it('should fail', function () {
+      var err = false;
+      try {
+        var obj1 = { foo: 'bar' };
+        var obj2 = { baz: 'qax' };
+        assert.deepEqual(obj1, obj2);
+      } catch (e) {
+        err = e;
+      }
+      if (!err) throw new Error('didn\'t throw');
+      assert.equal('obj1 deep equal obj2', err.message);
+    });
+  });
+
+  describe('.notDeepEqual', function () {
+    it('should pass', function () {
+      assert.notDeepEqual({ foo: 'bar' }, { baz: 'qax' });
+    });
+
+    it('should fail', function () {
+      var err = false;
+      try {
+        var obj1 = { foo: 'bar' };
+        var obj2 = { foo: 'bar' };
+        assert.notDeepEqual(obj1, obj2);
+      } catch (e) {
+        err = e;
+      }
+      if (!err) throw new Error('didn\'t throw');
+      assert.equal('obj1 not deep equal obj2', err.message);
+    });
+  });
+
+  describe('.ifError', function () {
+    it('should pass', function () {
+      assert.ifError(null);
+    });
+    it('should fail', function () {
+      var err = false;
+      try {
+        assert.ifError(new Error);
+      } catch (e) {
+        err = e;
+      }
+      if (!err) throw new Error('didn\'t throw');
+      assert.equal('new Error', err.message);
+    });
+  });
+
+  describe('.throws', function () {
+    it('should pass', function () {
+      assert.throws(function () {
+        throw new Error;
+      }, Error);
+    });
+    it('should fail', function () {
+      var err = false;
+      try {
+        assert.throws(function(){}, Error);
+      } catch (e) {
+        err = e;
+      }
+      if (!err) throw new Error('didn\'t throw');
+    });
+  });
+
+  describe('.doesNotThrow', function () {
+    it('should pass', function () {
+      assert.doesNotThrow(function(){}, Error);
+    });
+    it('should fail', function () {
+      var err = false;
+      try {
+        assert.doesNotThrow(function () {
+          throw new Error;
+        }, Error);
+      } catch (e) {
+        err = e;
+      }
+      if (!err) throw new Error('didn\'t throw');
+    });
+  });
+});


### PR DESCRIPTION
Makes this module much more user/node friendly.  I'm piggy backing on node's native `assert` for a few methods, as we're not able to to create friendly messages without massive hackery.

I also ran `npm init` to get rid of obnoxious npm warnings.
