### PR TITLE
Use getFunction instead of fun property

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function assert(expr) {
 
   var err = new AssertionError({
     message: src,
-    stackStartFunction: stack[0].fun
+    stackStartFunction: stack[0].getFunction()
   });
 
   throw err;


### PR DESCRIPTION
On node v0.11 better-assert does not output stack trace correctly:

```
$ node -v
v0.11.14

$ node example.js

/home/.../better-assert/index.js:37
  throw err;
        ^
AssertionError: 'number' == typeof user.age
```

Because `CallSite` object no longer has `fun` property.
This PR fix it by calling `getFunction` instead of `fun`:

```
$ node example.js

better-assert/index.js:37
  throw err;
        ^
AssertionError: 'number' == typeof user.age
    at test (/home/.../better-assert/example.js:9:3)
    at Object.<anonymous> (/home/.../better-assert/example.js:4:1)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:124:16)
    at node.js:842:3
```

Works fine on stable version:

```
$ node -v
v0.10.33

$ node example.js

/home/vagrant/Home/Development/oss/better-assert/index.js:37
  throw err;
        ^
AssertionError: 'number' == typeof user.age
    at test (/home/vagrant/Home/Development/oss/better-assert/example.js:9:3)
    at Object.<anonymous> (/home/vagrant/Home/Development/oss/better-assert/example.js:4:1)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```
