### PR TITLE
Improved fix for #12, extends pullreq #16: fix babel support issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 node_modules
 *.sock
+.idea
+

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,5 @@ support
 test
 examples
 *.sock
+.idea/
+

--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,7 @@
 
 # better-assert
 
-  Better c-style assertions using [callsite](https://github.com/visionmedia/callsite) for
-  self-documenting failure messages.
+  Better c-style assertions for self-documenting failure messages.
 
 ## Installation
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
  */
 
 var AssertionError = require('assert').AssertionError
-  , callsite = require('callsite')
   , fs = require('fs');
 
 /**
@@ -34,7 +33,14 @@ function assert(expr) {
     var lineno = parseInt(m[3]);
     var fullsource = fs.readFileSync(file, 'utf8');
     var line = fullsource.split('\n')[lineno-1];
-    var src = line.match(/.*assert\((.*)\)/)[1];
+    var m = line.match(/assert\((.*)\)/);
+    if (!m) {
+        // however, if the entire file doesn't carry any assert() lines any more,
+        // our next bet is this source file was transpiled by babel:
+        m = line.match(/\(0, [\w_]+\.default\)\((.*)\)/);
+    }
+
+    var src = m ? m[1] : "???";
     var err = new AssertionError({
         message: src + "\n ",
         stackStartFunction: assert

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 
 var AssertionError = require('assert').AssertionError
   , callsite = require('callsite')
-  , fs = require('fs')
+  , fs = require('fs');
 
 /**
  * Expose `assert`.
@@ -21,18 +21,24 @@ module.exports = process.env.NO_ASSERT
 function assert(expr) {
   if (expr) return;
 
-  var stack = callsite();
-  var call = stack[1];
-  var file = call.getFileName();
-  var lineno = call.getLineNumber();
-  var src = fs.readFileSync(file, 'utf8');
-  var line = src.split('\n')[lineno-1];
-  var src = line.match(/assert\((.*)\)/)[1];
-
-  var err = new AssertionError({
-    message: src,
-    stackStartFunction: stack[0].getFunction()
-  });
-
-  throw err;
+    var a = new Error();
+    // 0 => Error
+    // 1 => at assert
+    // 2 =>  at Object.<anonymous> (/project/myproject/test/test-babel.js:15:1)', <= where the assert was raised !
+    // .....
+    //
+    var errorline = a.stack.split('\n')[2];
+    var m =  errorline.match(/at (.*)\((.*):([0-9]*):([0-9]*)\)/);
+    var func =  m[1]; // Object.<anonymous> ( not very useful)
+    var file =  m[2]; // filename
+    var lineno = parseInt(m[3]);
+    var fullsource = fs.readFileSync(file, 'utf8');
+    var line = fullsource.split('\n')[lineno-1];
+    var src = line.match(/.*assert\((.*)\)/)[1];
+    var err = new AssertionError({
+        message: src + "\n ",
+        stackStartFunction: assert
+    });
+    throw err;
 }
+

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
         "TonyHe <coolhzb@163.com>",
         "ForbesLindesay"
     ],
-    "dependencies": {
-        "callsite": "1.0.0"
-    },
+    "dependencies": {},
     "repository": {
         "type": "git",
         "url": "https://github.com/visionmedia/better-assert.git"

--- a/test/test-babel.js
+++ b/test/test-babel.js
@@ -1,0 +1,27 @@
+// run with babel-node
+//   install:
+//     * npm install --save-dev babel-core
+//     * npm install --save-dev babel-preset-es2015
+//     * npm install -g babel
+//       babel-node --presets es2015 ./test/test-babel.hs
+//
+// should display:
+// throw err;
+// ^
+// AssertionError: 1==2,"1 should be 2"
+//
+// at myFunction (/projects/better-assert/test/test-babel.js:23:5)
+// at Object.<anonymous> /projects/better-assert/test/test-babel.js:20:1)
+// at Module._compile (module.js:570:32)
+//...
+
+import assert from "..";
+
+
+
+function myFunction() {
+    assert(1==2,"1 should be 2");
+
+}
+
+myFunction();


### PR DESCRIPTION
Works for babel 7. Augments #16, fixes #12.

See fork https://github.com/GerHobbelt/better-assert for `npm test` tests including babel transpiled runs.

The key problem was when using a modern `import assert from ...` statement in your code, which is then transpiled by babel, which replaces the `assert(...)` calls which something like `(0, _.default)(...)` when you transpile to ES5 or similar old targets, resulting in the `/assert\(.../` line regex in better-assert to crash.

See also the pullreqqed code changes and commit message.